### PR TITLE
Add mock cluster endpoints for dashboard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,13 +7,20 @@ This module provides HTTP endpoints for ingesting feedback from multiple sources
 """
 
 from datetime import datetime, timezone
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from .models import FeedbackItem
-from .store import add_feedback_item
+from .models import FeedbackItem, IssueCluster
+from .store import (
+    add_cluster,
+    add_feedback_item,
+    get_all_clusters,
+    get_feedback_item,
+    get_cluster,
+    update_cluster,
+)
 
 app = FastAPI(
     title="FeedbackAgent Ingestion API",
@@ -119,3 +126,101 @@ def ingest_manual(request: ManualIngestRequest):
     )
     add_feedback_item(item)
     return {"status": "ok", "id": str(item.id)}
+
+
+@app.get("/clusters")
+def list_clusters():
+    """List all issue clusters with aggregated metadata."""
+
+    clusters = get_all_clusters()
+    results = []
+    for cluster in clusters:
+        feedback_items = [get_feedback_item(fid) for fid in cluster.feedback_ids]
+        sources = sorted({item.source for item in feedback_items if item})
+        results.append(
+            {
+                "id": cluster.id,
+                "title": cluster.title,
+                "summary": cluster.summary,
+                "count": len(cluster.feedback_ids),
+                "status": cluster.status,
+                "sources": sources,
+                "github_pr_url": cluster.github_pr_url,
+            }
+        )
+    return results
+
+
+@app.get("/clusters/{cluster_id}")
+def get_cluster_detail(cluster_id: UUID):
+    """Retrieve a cluster with its feedback items."""
+
+    cluster = get_cluster(cluster_id)
+    if not cluster:
+        raise HTTPException(status_code=404, detail="Cluster not found")
+
+    feedback_items = [get_feedback_item(fid) for fid in cluster.feedback_ids]
+    response = cluster.model_dump()
+    response["feedback_items"] = [item for item in feedback_items if item]
+    return response
+
+
+@app.post("/clusters/{cluster_id}/start_fix")
+def start_cluster_fix(cluster_id: UUID):
+    """Begin fix generation for a cluster (stub implementation)."""
+
+    cluster = get_cluster(cluster_id)
+    if not cluster:
+        raise HTTPException(status_code=404, detail="Cluster not found")
+
+    updated_cluster = update_cluster(cluster_id, status="fixing")
+    return {"status": "ok", "message": "Fix generation started", "cluster_id": updated_cluster.id}
+
+
+def seed_mock_data():
+    """Seed a handful of feedback items and clusters for local testing."""
+
+    now = datetime.now(timezone.utc)
+
+    feedback_one = FeedbackItem(
+        id=uuid4(),
+        source="reddit",
+        external_id="t3_mock1",
+        title="Export crashes on Safari",
+        body="App crashes when exporting on Safari 16.",
+        metadata={"subreddit": "mock_sub"},
+        created_at=now,
+    )
+    feedback_two = FeedbackItem(
+        id=uuid4(),
+        source="sentry",
+        external_id="evt_mock2",
+        title="TypeError in export job",
+        body="TypeError: cannot read properties of undefined",
+        metadata={},
+        created_at=now,
+    )
+    feedback_three = FeedbackItem(
+        id=uuid4(),
+        source="manual",
+        title="Export broken",
+        body="Manual report of export failing on Firefox",
+        metadata={},
+        created_at=now,
+    )
+
+    for item in (feedback_one, feedback_two, feedback_three):
+        add_feedback_item(item)
+
+    cluster = IssueCluster(
+        id=uuid4(),
+        title="Export failures",
+        summary="Users report export crashes across browsers.",
+        feedback_ids=[feedback_one.id, feedback_two.id, feedback_three.id],
+        status="new",
+        created_at=now,
+        updated_at=now,
+    )
+
+    add_cluster(cluster)
+    return {"cluster_id": cluster.id, "feedback_ids": [feedback_one.id, feedback_two.id, feedback_three.id]}

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,7 +1,7 @@
 """Domain models for FeedbackAgent data ingestion layer."""
 
 from datetime import datetime
-from typing import Dict, Literal, Optional
+from typing import Dict, List, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -31,3 +31,19 @@ class FeedbackItem(BaseModel):
     body: str
     metadata: Dict = {}
     created_at: datetime
+
+
+class IssueCluster(BaseModel):
+    """Represents a cluster of related feedback items."""
+
+    id: UUID
+    title: str
+    summary: str
+    feedback_ids: List[UUID]
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    embedding_centroid: Optional[List[float]] = None
+    github_branch: Optional[str] = None
+    github_pr_url: Optional[str] = None
+    error_message: Optional[str] = None

--- a/backend/store.py
+++ b/backend/store.py
@@ -1,4 +1,4 @@
-"""In-memory storage for FeedbackItems.
+"""In-memory storage for FeedbackItems and IssueClusters.
 
 This module provides a simple in-memory store for the MVP.
 In production, this would be replaced with a database (Supabase/Postgres).
@@ -6,10 +6,11 @@ In production, this would be replaced with a database (Supabase/Postgres).
 
 from typing import Dict, List
 from uuid import UUID
-from .models import FeedbackItem
+from .models import FeedbackItem, IssueCluster
 
 # In-memory storage for feedback items, keyed by UUID
 feedback_items: Dict[UUID, FeedbackItem] = {}
+issue_clusters: Dict[UUID, IssueCluster] = {}
 
 
 def add_feedback_item(item: FeedbackItem) -> FeedbackItem:
@@ -52,3 +53,37 @@ def get_all_feedback_items() -> List[FeedbackItem]:
 def clear_feedback_items():
     """Clear all feedback items from the store. Used primarily for testing."""
     feedback_items.clear()
+
+
+def add_cluster(cluster: IssueCluster) -> IssueCluster:
+    """Store an issue cluster in memory."""
+
+    issue_clusters[cluster.id] = cluster
+    return cluster
+
+
+def get_cluster(cluster_id: UUID) -> IssueCluster | None:
+    """Retrieve a cluster by its ID."""
+
+    return issue_clusters.get(cluster_id)
+
+
+def get_all_clusters() -> List[IssueCluster]:
+    """Retrieve all stored clusters."""
+
+    return list(issue_clusters.values())
+
+
+def update_cluster(cluster_id: UUID, **updates) -> IssueCluster:
+    """Update and return a cluster with the given fields."""
+
+    cluster = issue_clusters[cluster_id]
+    updated_cluster = cluster.model_copy(update=updates)
+    issue_clusters[cluster_id] = updated_cluster
+    return updated_cluster
+
+
+def clear_clusters():
+    """Clear all clusters from the store. Used primarily for testing."""
+
+    issue_clusters.clear()

--- a/backend/tests/test_clusters.py
+++ b/backend/tests/test_clusters.py
@@ -1,0 +1,107 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.models import FeedbackItem, IssueCluster
+from backend.store import (
+    add_cluster,
+    add_feedback_item,
+    clear_clusters,
+    clear_feedback_items,
+    get_cluster,
+)
+
+
+client = TestClient(app)
+
+
+def setup_function():
+    clear_clusters()
+    clear_feedback_items()
+
+
+def _seed_cluster_with_feedback():
+    now = datetime.now(timezone.utc)
+
+    feedback_one = FeedbackItem(
+        id=uuid4(),
+        source="reddit",
+        external_id="ext_1",
+        title="Crash on export",
+        body="Export crashes on Safari",
+        metadata={},
+        created_at=now,
+    )
+    feedback_two = FeedbackItem(
+        id=uuid4(),
+        source="sentry",
+        external_id="ext_2",
+        title="Type error",
+        body="TypeError: undefined",
+        metadata={},
+        created_at=now,
+    )
+
+    for item in (feedback_one, feedback_two):
+        add_feedback_item(item)
+
+    cluster = IssueCluster(
+        id=uuid4(),
+        title="Export issues",
+        summary="Crashes and type errors during export flow",
+        feedback_ids=[feedback_one.id, feedback_two.id],
+        status="new",
+        created_at=now,
+        updated_at=now,
+    )
+    add_cluster(cluster)
+    return cluster, [feedback_one, feedback_two]
+
+
+def test_list_clusters_returns_transformed_items():
+    cluster, feedback_items = _seed_cluster_with_feedback()
+
+    response = client.get("/clusters")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+
+    cluster_item = data[0]
+    assert cluster_item["id"] == str(cluster.id)
+    assert cluster_item["count"] == len(feedback_items)
+    assert set(cluster_item["sources"]) == {"reddit", "sentry"}
+    assert cluster_item["summary"] == cluster.summary
+
+
+def test_get_cluster_detail_returns_feedback_items():
+    cluster, feedback_items = _seed_cluster_with_feedback()
+
+    response = client.get(f"/clusters/{cluster.id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(cluster.id)
+    assert len(body["feedback_items"]) == len(feedback_items)
+    returned_ids = {item["id"] for item in body["feedback_items"]}
+    assert returned_ids == {str(item.id) for item in feedback_items}
+
+
+def test_get_cluster_detail_missing_returns_404():
+    response = client.get(f"/clusters/{uuid4()}")
+
+    assert response.status_code == 404
+
+
+def test_start_fix_updates_cluster_status():
+    cluster, _ = _seed_cluster_with_feedback()
+
+    response = client.post(f"/clusters/{cluster.id}/start_fix")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+    updated_cluster = get_cluster(cluster.id)
+    assert updated_cluster.status == "fixing"


### PR DESCRIPTION
## Summary
- add IssueCluster model and in-memory cluster store for mock data
- implement cluster list/detail endpoints with stub fix start and optional seeding helper
- add cluster endpoint tests covering listing, detail, 404, and status updates

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692238d0911c8322b58b32e4bef37235)