### PR TITLE
Update documentation and dashboard components to remove Sentry integr…

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -6,7 +6,7 @@ Next.js dashboard for the FeedbackAgent self-healing dev loop system.
 
 This dashboard provides a web interface for:
 
-- Viewing clustered issues from Reddit and Sentry feedback
+- Viewing clustered issues from Reddit and GitHub feedback
 - Reviewing cluster details and associated feedback items
 - Triggering the coding agent to generate fixes
 - Monitoring PR creation status

--- a/dashboard/app/clusters/[id]/page.tsx
+++ b/dashboard/app/clusters/[id]/page.tsx
@@ -89,8 +89,8 @@ export default function ClusterDetailPage() {
     switch (source) {
       case 'reddit':
         return '🗨️ Reddit';
-      case 'sentry':
-        return '⚠️ Sentry';
+      case 'github':
+        return '🐙 GitHub';
       case 'manual':
         return '✍️ Manual';
     }

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -72,7 +72,7 @@ export default function Home() {
             </div>
             <h3 className="text-xl font-bold text-white mb-3 group-hover:text-matrix-green transition-colors">Listen</h3>
             <p className="text-gray-400 leading-relaxed">
-              Automatically ingests feedback from Reddit communities and Sentry error reports in
+              Automatically ingests feedback from Reddit communities and GitHub issues in
               real-time.
             </p>
           </div>

--- a/dashboard/components/FeedbackCard.tsx
+++ b/dashboard/components/FeedbackCard.tsx
@@ -50,8 +50,6 @@ export default function FeedbackCard({ item }: FeedbackCardProps) {
             />
           </svg>
         );
-      case 'sentry':
-        return '⚠️';
       case 'manual':
         return '✍️';
     }
@@ -63,8 +61,6 @@ export default function FeedbackCard({ item }: FeedbackCardProps) {
         return 'bg-orange-900/20 text-orange-400 border border-orange-900/50';
       case 'github':
         return 'bg-purple-900/20 text-purple-400 border border-purple-900/50';
-      case 'sentry':
-        return 'bg-red-900/20 text-red-400 border border-red-900/50';
       case 'manual':
         return 'bg-matrix-green-dim text-matrix-green border border-matrix-green/30';
     }

--- a/dashboard/components/FeedbackList.tsx
+++ b/dashboard/components/FeedbackList.tsx
@@ -91,7 +91,7 @@ export default function FeedbackList({ refreshTrigger }: FeedbackListProps) {
     <div>
       {/* Filter tabs */}
       <div className="flex gap-2 mb-6 border-b border-white/10 pb-1">
-        {(['all', 'reddit', 'github', 'sentry', 'manual'] as const).map((filter) => (
+        {(['all', 'reddit', 'github', 'manual'] as const).map((filter) => (
           <button
             key={filter}
             onClick={() => setSourceFilter(filter)}
@@ -135,7 +135,7 @@ export default function FeedbackList({ refreshTrigger }: FeedbackListProps) {
           <h3 className="text-lg font-medium text-white">No feedback items found</h3>
           <p className="mt-2 text-sm text-slate-400 max-w-sm mx-auto">
             {sourceFilter === 'all'
-              ? 'Start by submitting manual feedback or configuring Reddit/Sentry sources.'
+              ? 'Start by submitting manual feedback or configuring Reddit sources.'
               : `No ${sourceFilter} feedback items yet.`}
           </p>
         </div>

--- a/dashboard/components/SourceConfig.tsx
+++ b/dashboard/components/SourceConfig.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import type { GitHubRepo } from '@/types';
 
-type SourceType = 'reddit' | 'sentry' | 'github';
+type SourceType = 'reddit' | 'github';
 
 export default function SourceConfig() {
   const [selectedSource, setSelectedSource] = useState<SourceType | null>(null);
@@ -70,12 +70,6 @@ export default function SourceConfig() {
       icon: '⚙️',
       title: 'GitHub Issues',
       description: 'Sync open-source repository issues automatically',
-    },
-    {
-      type: 'sentry' as const,
-      icon: '⚠️',
-      title: 'Sentry Webhook',
-      description: 'Receive error reports from Sentry in real-time',
     },
   ];
 
@@ -444,44 +438,6 @@ export default function SourceConfig() {
             {repoError && <p className="text-sm text-rose-400">{repoError}</p>}
             <p className="text-xs text-slate-500">
               Supports public repos. Set GITHUB_TOKEN for higher rate limits (5000/hr vs 60/hr).
-            </p>
-          </div>
-        </div>
-      )}
-
-      {selectedSource === 'sentry' && (
-        <div className="border-t border-white/10 pt-4 space-y-3 relative z-10">
-          <h4 className="font-semibold text-slate-200">Sentry Setup Instructions</h4>
-          <div className="bg-black/20 border border-white/5 p-4 rounded-xl text-sm space-y-2">
-            <p className="text-slate-300">
-              <strong>1. Configure webhook URL in Sentry:</strong>
-            </p>
-            <pre className="bg-black/60 border border-white/10 text-emerald-400/90 p-3 rounded-lg overflow-x-auto font-mono text-xs">
-              {typeof window !== 'undefined'
-                ? `${window.location.origin}/api/ingest/sentry`
-                : 'http://your-domain.com/api/ingest/sentry'}
-            </pre>
-
-            <p className="text-slate-300">
-              <strong>2. In Sentry project settings:</strong>
-            </p>
-            <ul className="list-disc list-inside space-y-1 text-slate-400">
-              <li>Go to Settings → Integrations → WebHooks</li>
-              <li>Add the webhook URL above</li>
-              <li>Enable "Issue" events</li>
-              <li>Save the webhook configuration</li>
-            </ul>
-
-            <p className="text-slate-500 mt-3">
-              📖 Learn more at{' '}
-              <a
-                href="https://docs.sentry.io/product/integrations/integration-platform/webhooks/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-emerald-400 hover:underline"
-              >
-                Sentry Webhook Docs
-              </a>
             </p>
           </div>
         </div>

--- a/dashboard/lib/redis.ts
+++ b/dashboard/lib/redis.ts
@@ -70,7 +70,7 @@ export async function getFeedbackItem(id: string): Promise<FeedbackItem | null> 
 
   return {
     id: data.id as string,
-    source: data.source as 'reddit' | 'sentry' | 'manual' | 'github',
+    source: data.source as 'reddit' | 'manual' | 'github',
     external_id: data.external_id as string | null | undefined,
     title: data.title as string,
     body: data.body as string,
@@ -116,7 +116,7 @@ export async function getClusters(): Promise<ClusterListItem[]> {
         summary: cluster.summary,
         count: feedbackIds.length,
         status: cluster.status,
-        sources: sources as ('reddit' | 'sentry' | 'manual')[],
+        sources: sources as ('reddit' | 'manual' | 'github')[],
         repos: repos.length > 0 ? repos : undefined,
         created_at: cluster.created_at,
         ...(cluster.github_pr_url && { github_pr_url: cluster.github_pr_url }),
@@ -220,7 +220,7 @@ export async function getFeedback(
  */
 export async function getStats(): Promise<{
   total_feedback: number;
-  by_source: { reddit: number; sentry: number; manual: number; github: number };
+  by_source: { reddit: number; manual: number; github: number };
   total_clusters: number;
 }> {
   // Get total feedback count using ZCARD (more efficient than ZRANGE)
@@ -228,7 +228,6 @@ export async function getStats(): Promise<{
 
   // Get counts by source using ZCARD (more efficient than ZRANGE)
   const redditCount = (await redis.zcard('feedback:source:reddit')) || 0;
-  const sentryCount = (await redis.zcard('feedback:source:sentry')) || 0;
   const manualCount = (await redis.zcard('feedback:source:manual')) || 0;
   const githubCount = (await redis.zcard('feedback:source:github')) || 0;
 
@@ -239,7 +238,6 @@ export async function getStats(): Promise<{
     total_feedback,
     by_source: {
       reddit: redditCount,
-      sentry: sentryCount,
       manual: manualCount,
       github: githubCount,
     },
@@ -288,7 +286,7 @@ export async function createFeedback(data: {
   title: string;
   body: string;
   github_repo_url?: string;
-  source?: 'reddit' | 'sentry' | 'manual';
+  source?: 'reddit' | 'manual';
   metadata?: Record<string, any>;
 }): Promise<string> {
   const id = randomUUID();

--- a/dashboard/types/index.ts
+++ b/dashboard/types/index.ts
@@ -1,6 +1,6 @@
 // Shared TypeScript types for FeedbackAgent dashboard
 
-export type FeedbackSource = 'reddit' | 'sentry' | 'manual' | 'github';
+export type FeedbackSource = 'reddit' | 'manual' | 'github';
 
 export type ClusterStatus = 'new' | 'fixing' | 'pr_opened' | 'failed';
 
@@ -33,7 +33,6 @@ export interface StatsResponse {
   total_feedback: number;
   by_source: {
     reddit: number;
-    sentry: number;
     manual: number;
     github: number;
   };


### PR DESCRIPTION
…ation

- Revised CLAUDE.md to reflect changes in the feedback ingestion sources, replacing Sentry with GitHub.
- Updated README.md and various dashboard components to ensure consistency in terminology and functionality, focusing on GitHub feedback.
- Removed references to Sentry from the FeedbackCard, FeedbackList, and SourceConfig components.
- Adjusted types and API responses to eliminate Sentry-related data handling.

These changes streamline the system to focus solely on Reddit and GitHub as feedback sources, enhancing clarity and usability.