### PR TITLE
Update repository links in README and dashboard components

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The system consists of three main components:
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/yourusername/soulcaster.git
+git clone https://github.com/altock/soulcaster.git
 cd soulcaster
 ```
 

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -46,7 +46,7 @@ export default function Home() {
               </span>
             </Link>
 
-            <a href="https://github.com/soulcaster-ai" target="_blank" rel="noopener noreferrer" className="inline-flex h-10 items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 text-sm font-normal text-slate-200 hover:bg-white/10 hover:border-white/20 hover:scale-105 transition-all active:scale-95">
+            <a href="https://github.com/altock/soulcaster" target="_blank" rel="noopener noreferrer" className="inline-flex h-10 items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 text-sm font-normal text-slate-200 hover:bg-white/10 hover:border-white/20 hover:scale-105 transition-all active:scale-95">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
               </svg>


### PR DESCRIPTION
- Changed the GitHub repository URL in README.md to reflect the correct owner.
- Updated the link in the dashboard's page.tsx to point to the new GitHub repository, ensuring consistency across documentation and UI.

These changes improve the accuracy of references to the repository, enhancing user experience and accessibility.