### PR TITLE
Rename FeedbackAgent branding to Soulcaster

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,7 +98,7 @@ E2B_API_KEY=your-e2b-api-key
 KILOCODE_TEMPLATE_NAME=kilo-sandbox-v-0-1-dev
 
 # Git configuration for commits made by the coding agent
-# GIT_USER_NAME=FeedbackAgent
+# GIT_USER_NAME=Soulcaster
 # GIT_USER_EMAIL=agent@example.com
 
 # GitHub token used by the agent (same as above)

--- a/backend/github_client.py
+++ b/backend/github_client.py
@@ -31,7 +31,7 @@ def _auth_headers(token: Optional[str] = None) -> Dict[str, str]:
     """
     headers = {
         "Accept": "application/vnd.github+json",
-        "User-Agent": "FeedbackAgent/1.0",
+        "User-Agent": "Soulcaster/1.0",
     }
     # Use provided token, or fall back to env var
     auth_token = token or os.getenv("GITHUB_TOKEN")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-"""FastAPI application for FeedbackAgent data ingestion.
+"""FastAPI application for Soulcaster data ingestion.
 
 This module provides HTTP endpoints for ingesting feedback from multiple sources:
 - Reddit posts (normalized via reddit_poller)
@@ -115,7 +115,7 @@ import agent_runner.sandbox
 import agent_runner.aws
 
 app = FastAPI(
-    title="FeedbackAgent Ingestion API",
+    title="Soulcaster Ingestion API",
     description="API for ingesting user feedback from multiple sources",
     version="0.1.0",
 )
@@ -147,7 +147,7 @@ GITHUB_SYNC_STATE: Dict[Tuple[str, str], Dict[str, str]] = {}
 @app.get("/")
 def read_root():
     """Health check endpoint."""
-    return {"status": "ok", "service": "feedbackagent-ingestion"}
+    return {"status": "ok", "service": "soulcaster-ingestion"}
 
 
 def _require_project_id(project_id: Optional[UUID | str]) -> str:

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-"""Domain models for FeedbackAgent data ingestion layer."""
+"""Domain models for Soulcaster data ingestion layer."""
 
 from datetime import datetime
 from typing import Dict, List, Literal, Optional, Union
@@ -71,7 +71,7 @@ class FeedbackItem(BaseModel):
     Represents a single piece of user feedback from any source.
 
     This model normalizes feedback from different sources (Reddit, Sentry, manual, GitHub, Splunk, PostHog, Datadog)
-    into a consistent schema for processing by the FeedbackAgent system.
+    into a consistent schema for processing by the Soulcaster system.
 
     Attributes:
         id: Unique identifier for this feedback item

--- a/backend/reddit_poller.py
+++ b/backend/reddit_poller.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     _store_get_reddit_subreddits = None
 
-USER_AGENT = "Mozilla/5.0 (FeedbackAgentHackathon/0.1)"
+USER_AGENT = "Mozilla/5.0 (SoulcasterHackathon/0.1)"
 SUPPORTED_SORTS = {"new", "hot", "top"}
 DEFAULT_SORTS = ["new"]
 DEFAULT_POLL_INTERVAL = 300  # seconds

--- a/dashboard/CI_SETUP.md
+++ b/dashboard/CI_SETUP.md
@@ -1,6 +1,6 @@
 # CI/CD Setup
 
-This document describes the CI/CD setup for the FeedbackAgent dashboard.
+This document describes the CI/CD setup for the Soulcaster dashboard.
 
 ## What's Configured
 

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -15,12 +15,12 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'FeedbackAgent Dashboard',
+  title: 'Soulcaster Dashboard',
   description: 'Self-healing dev loop triage dashboard',
 };
 
 /**
- * Provides the root HTML layout for the FeedbackAgent dashboard.
+ * Provides the root HTML layout for the Soulcaster dashboard.
  *
  * Renders the document scaffold including <html lang="en">, a styled <body>, a header with the dashboard title, and a main content area that hosts `children`.
  *

--- a/dashboard/lib/github.ts
+++ b/dashboard/lib/github.ts
@@ -3,18 +3,18 @@ import type { FeedbackItem, GitHubRepo } from '@/types';
 import { getGitHubToken } from '@/lib/auth';
 
 /**
- * Create an Octokit client configured with an optional GitHub token and a FeedbackAgent user agent.
+ * Create an Octokit client configured with an optional GitHub token and a Soulcaster user agent.
  *
  * Using a token increases API rate limits (e.g., authenticated requests have higher limits than anonymous requests).
  *
- * @returns An Octokit client configured with `auth` (if a token is available) and `userAgent: 'FeedbackAgent/1.0'`.
+ * @returns An Octokit client configured with `auth` (if a token is available) and `userAgent: 'Soulcaster/1.0'`.
  */
 async function getOctokit() {
   const token = await getGitHubToken();
 
   return new Octokit({
     auth: token,
-    userAgent: 'FeedbackAgent/1.0',
+    userAgent: 'Soulcaster/1.0',
   });
 }
 

--- a/dashboard/types/index.ts
+++ b/dashboard/types/index.ts
@@ -1,4 +1,4 @@
-// Shared TypeScript types for FeedbackAgent dashboard
+// Shared TypeScript types for Soulcaster dashboard
 
 export type FeedbackSource = 'reddit' | 'manual' | 'github';
 

--- a/docs/chatgpt-design.md
+++ b/docs/chatgpt-design.md
@@ -1,4 +1,4 @@
-# FeedbackAgent Productionization Design (Product Hunt beta)
+# Soulcaster Productionization Design (Product Hunt beta)
 
 ## Goal and guardrails
 - Ship a resilient “good enough” loop for Product Hunt/early users while keeping costs and complexity low.


### PR DESCRIPTION
## Summary
- update branding references from FeedbackAgent to Soulcaster across documentation and configuration
- refresh backend metadata and user agents to use Soulcaster naming
- align dashboard metadata, types, and GitHub utilities with the Soulcaster brand

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69448a64a9908322bd6c0526511efd89)