### PR TITLE
Remove AI powered text from dashboard layout

### DIFF
--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: 'Soulcaster',
   description:
-    'AI-powered feedback triage and automated fix generation. Ingest bug reports, cluster similar issues, and generate PRs automatically.',
+    'Feedback triage and automated fix generation. Ingest bug reports, cluster similar issues, and generate PRs automatically.',
   icons: {
     icon: '/favicon.svg',
     apple: '/favicon.svg',
@@ -25,14 +25,14 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Soulcaster',
     description:
-      'AI-powered feedback triage and automated fix generation. Ingest bug reports, cluster similar issues, and generate PRs automatically.',
+      'Feedback triage and automated fix generation. Ingest bug reports, cluster similar issues, and generate PRs automatically.',
     type: 'website',
   },
   twitter: {
     card: 'summary',
     title: 'Soulcaster',
     description:
-      'AI-powered feedback triage and automated fix generation. Ingest bug reports, cluster similar issues, and generate PRs automatically.',
+      'Feedback triage and automated fix generation. Ingest bug reports, cluster similar issues, and generate PRs automatically.',
   },
 };
 


### PR DESCRIPTION
Update description, openGraph, and twitter metadata to remove "AI-powered" prefix from the feedback triage description.