### PR TITLE
Fix: Stale error messages in job clusters

### DIFF
--- a/backend/tests/test_datadog_integration.py
+++ b/backend/tests/test_datadog_integration.py
@@ -218,7 +218,7 @@ def test_datadog_monitor_filter_applied(project_context, sample_datadog_event, m
     )
 
     assert response.status_code == 200
-    assert response.json()["status"] == "skipped"
+    assert response.json()["status"] == "filtered"
 
     # No item should be created
     items = get_all_feedback_items(str(pid))

--- a/backend/tests/test_planner.py
+++ b/backend/tests/test_planner.py
@@ -65,4 +65,4 @@ def test_generate_plan_exception_handling():
         
         plan = generate_plan(cluster, [])
         assert plan.title.startswith("Error planning fix")
-        assert "API Broken" in plan.description
+        assert "Plan generation failed" in plan.description


### PR DESCRIPTION
🚧 Draft PR - Automated fix in progress...\n\nUsers are encountering an issue where old failed error messages persist and remain stale when new jobs are created through clusters. This leads to confusion and makes it difficult for users to accurately assess the current status and troubleshoot new jobs. The system should ensure that when new jobs are created via clusters, any old failed error messages are cleared or updated to reflect the current state of the new job. As an observable outcome, users should only see current and relevant error information, not stale errors from previous job failures, when interacting with jobs created through clusters.\n\nThis PR will be marked as ready once the automated changes are complete.