### PR TITLE
Fix: Stale error messages in job clusters

### DIFF
--- a/backend/store.py
+++ b/backend/store.py
@@ -172,6 +172,11 @@ class UpstashRESTClient:
         # Convert list to dict
         return dict(zip(result[0::2], result[1::2]))
 
+    def hdel(self, key: str, *fields: str) -> int:
+        if not fields:
+            return 0
+        return int(self._cmd("HDEL", key, *fields) or 0)
+
     def zadd(self, key: str, score: float, member: str):
         return self._cmd("ZADD", key, str(score), member)
 
@@ -1627,6 +1632,11 @@ class RedisStore:
         hash_payload = {k: str(v) for k, v in payload.items() if v is not None}
         key = self._cluster_key(project_id, cluster.id)
         self._hset(key, hash_payload)
+
+        # Clear fields that are None in the model but might exist in Redis
+        fields_to_remove = [k for k, v in payload.items() if v is None]
+        if fields_to_remove:
+            self._hdel(key, *fields_to_remove)
         
         # Use ZSET with created_at timestamp as score for sorted retrieval
         score = cluster.created_at.timestamp() if cluster.created_at else 0.0
@@ -2519,6 +2529,14 @@ class RedisStore:
             self.client.hset(key, mapping=mapping)
         else:
             self.client.hset(key, mapping)
+
+    def _hdel(self, key: str, *fields: str):
+        if not fields:
+            return
+        if self.mode == "redis":
+            self.client.hdel(key, *fields)
+        else:
+            self.client.hdel(key, *fields)
 
     def _hgetall(self, key: str) -> Dict[str, str]:
         if self.mode == "redis":


### PR DESCRIPTION
```markdown
## Stale error messages in job clusters

### 1. Summary: What problem does this fix and how?

This PR resolves an issue where old, failed error messages persisted and remained stale when new jobs were created or updated via clusters. This led to user confusion as the displayed status did not accurately reflect the current state of the job cluster.

The fix ensures that when a `Cluster` object is persisted, any fields in the update payload that have a `None` value are explicitly deleted from the underlying Redis hash. This mechanism effectively clears outdated error messages (or any other irrelevant fields that should be absent), guaranteeing that users only see current and relevant information about their job clusters.

### 2. Changes Made: What files/code were modified?

*   `backend/store.py`:
    *   A new `hdel` method was added to the `UpstashRESTClient` to provide support for deleting specific fields from a Redis hash.
    *   A private `_hdel` helper method was introduced in `RedisStore` to abstract hash deletion calls, ensuring compatibility with both Redis and Upstash clients.
    *   The `_persist_cluster` method in `RedisStore` was modified. It now identifies fields in the update `payload` where the value is `None` and explicitly calls `_hdel` to remove these fields from the cluster's Redis hash.

### 3. Test Plan: How should this be tested?

1.  **Initial State with Error:**
    *   Create a job cluster through the standard process.
    *   Simulate or trigger a scenario where the job cluster encounters an error, ensuring an error message is populated and visible (e.g., by running a faulty job definition, or if possible, manually setting an error field via a debugging tool or direct API call).
    *   Verify that the error message is correctly displayed when fetching the cluster's status.
2.  **Update to Clear Error:**
    *   Perform an action that would typically clear or reset the error state for the job cluster (e.g., re-running the job with a fix, or updating the cluster via an API call where the error-related field is explicitly set to `None`).
3.  **Verify Resolution:**
    *   Fetch the updated job cluster's status.
    *   **Expected Outcome:** The previously displayed stale error message should no longer be visible. Only the current, accurate status of the job cluster should be presented.
```

---
🤖 Generated with Soulcaster Agent
