### PR TITLE
Add production Docker setup and fix missing AWS runner import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -114,7 +114,6 @@ from sentry_client import (
 from datadog_client import datadog_event_to_feedback_item, verify_signature
 # Ensure runners are registered
 import agent_runner.sandbox
-import agent_runner.aws
 
 app = FastAPI(
     title="Soulcaster Ingestion API",


### PR DESCRIPTION

Fixes deployment crash: ModuleNotFoundError: No module named 'agent_runner.aws'

🤖 Generated with Claude Code