### PR TITLE
fix: Remove readme and license fields from pyproject.toml

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,9 +2,7 @@
 name = "soulcaster-backend"
 version = "0.1.0"
 description = "Soulcaster backend API - Feedback triage and automated fix generation"
-readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
 authors = [
     { name = "Soulcaster Team" }
 ]


### PR DESCRIPTION
Removed non-existent README.md reference and incorrect MIT license declaration that were causing Docker build failures during deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)